### PR TITLE
Rename 'AccountsDates' interface to 'AccountsDatesHelper'

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accountsdates/AccountsDatesHelper.java
+++ b/src/main/java/uk/gov/companieshouse/accountsdates/AccountsDatesHelper.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 
 @Service
-public interface AccountsDates {
+public interface AccountsDatesHelper {
     
     /**
      * Takes a {@link String} and converts it to a Java 8 {@link LocalDate}
@@ -63,6 +63,17 @@ public interface AccountsDates {
      * @return
      */
     public String generateBalanceSheetHeading(String periodStartString, String periodEndString, boolean isSameYear);
+
+    /**
+     * Generate balance sheet header string to display on web and ixbrl templates based on period start and end
+     * dates
+     *
+     * @param periodStart accounting period start date
+     * @param periodEnd accounting period end date
+     * @param isSameYear
+     * @return
+     */
+    public String generateBalanceSheetHeading(LocalDate periodStart, LocalDate periodEnd, boolean isSameYear);
 
     /**
      *Calculate balance sheet dates display format depending on range between period start and end dates

--- a/src/main/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImpl.java
@@ -14,9 +14,9 @@ import java.util.List;
 import java.util.Map;
 
 
-import uk.gov.companieshouse.accountsdates.AccountsDates;
+import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 
-public class AccountsDatesImpl implements AccountsDates {
+public class AccountsDatesHelperImpl implements AccountsDatesHelper {
 
     private static final String PERIOD_START = "periodStart";
     private static final String PERIOD_END = "periodEnd";
@@ -116,6 +116,27 @@ public class AccountsDatesImpl implements AccountsDates {
     public String generateBalanceSheetHeading(String periodStartString, String periodEndString, boolean isSameYear) {
 
         Map<String, String> resultDates = calculatePeriodRange(convertStringToDate(periodStartString), convertStringToDate(periodEndString), isSameYear);
+
+        return generateBalanceSheetHeading(resultDates);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String generateBalanceSheetHeading(LocalDate periodStart, LocalDate periodEnd, boolean isSameYear) {
+
+        Map<String, String> resultDates = calculatePeriodRange(periodStart, periodEnd, isSameYear);
+
+        return generateBalanceSheetHeading(resultDates);
+    }
+
+    /**
+     * Generate balance sheet heading for a given calculated period date range
+     * @param resultDates calculated period date range
+     * @return balance sheet heading
+     */
+    private String generateBalanceSheetHeading(Map<String, String> resultDates) {
 
         if (!resultDates.containsKey(PERIOD_START)) {
             return resultDates.get(PERIOD_END);

--- a/src/test/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImplTest.java
@@ -16,14 +16,14 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-public class AccountsDatesImplTest {
+public class AccountsDatesHelperImplTest {
 
 	private static final String YYYY_MM_DD = "yyyy-MM-dd";
 	private static final String PERIOD_START = "periodStart";
 	private static final String PERIOD_END = "periodEnd";
 
 	private SimpleDateFormat simpleDateFormat;
-	private AccountsDatesImpl datesHelper = new AccountsDatesImpl();
+	private AccountsDatesHelperImpl datesHelper = new AccountsDatesHelperImpl();
 
 	@Test
 	public void convertStringtoDate() throws ParseException {

--- a/src/test/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/accountsdates/impl/AccountsDatesHelperImplTest.java
@@ -282,4 +282,41 @@ public class AccountsDatesHelperImplTest {
 				datesHelper.generateBalanceSheetHeading("2014-06-01", "2015-06-30", true));
 
 	}
+
+	@Test
+	public void generateBalanceSheetHeadingWithLocalDate() {
+
+		// test yyyy returned for 12 month period
+		assertEquals("2017",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2016-01-01"), LocalDate.parse("2017-01-14"), false));
+
+		// Test 381 days shows month (more than 12 month period)
+		assertEquals("13 months to 16 February 2016",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2015-02-01"), LocalDate.parse("2016-02-16"), false));
+
+		// Test 349 days shows month (less than 12 month period)
+		assertEquals("11 months to 1 January 2017",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2016-01-19"), LocalDate.parse("2017-01-01"), false));
+
+		// Test exactly 381 days shows months leap year
+		assertEquals("13 months to 16 February 2015",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2014-02-01"), LocalDate.parse("2015-02-16"), false));
+
+		// Test 336 days shows 'month' rather than 'months'
+		assertEquals("1 month to 1 April 2015",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2015-03-07"), LocalDate.parse("2015-04-01"), false));
+
+		// "Test exactly 351 days show yyyy"
+		assertEquals("2015",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2014-04-01"), LocalDate.parse("2015-03-16"), false));
+
+		// Test exactly 351 days show years leap year
+		assertEquals("2016",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2015-04-01"), LocalDate.parse("2016-03-16"), false));
+
+		// Test 1st year filing within 15 days either side of 1 year period with same
+		// year is just year
+		assertEquals("30 June 2015",
+				datesHelper.generateBalanceSheetHeading(LocalDate.parse("2014-06-01"), LocalDate.parse("2015-06-30"), true));
+	}
 }


### PR DESCRIPTION
- Refactor interface name to be synonymous with its helper functionality
- Add method to interface to generate balance sheet headings when providing LocalDate's