### PR TITLE
Add authentication interceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,12 @@
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     <structured-logging.version>1.2.0-rc1</structured-logging.version>
+    <api-security-java.version>0.2.9</api-security-java.version>
 
     <!-- JUnit testing -->
     <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
     <junit-jupiter-api.version>5.1.0</junit-jupiter-api.version>
+    <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
     <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
 
     <!-- JDK -->
@@ -38,7 +40,7 @@
 
     <!-- Repositories -->
     <artifactoryResolveSnapshotRepo>libs-snapshot-local</artifactoryResolveSnapshotRepo>
-    <artifactoryResolveReleaseRepo>libs-release-local</artifactoryResolveReleaseRepo>
+    <artifactoryResolveReleaseRepo>virtual-release</artifactoryResolveReleaseRepo>
 
     <!-- Sonar -->
     <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
@@ -77,6 +79,12 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>uk.gov.companieshouse</groupId>
+      <artifactId>api-security-java</artifactId>
+      <version>${api-security-java.version}</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -88,6 +96,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit-jupiter-api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito-junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Component
+public class AuthenticationInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("company-accounts-library");
+
+    /**
+     * Pre handle method to authorize the request before it reaches the controller.
+     * Retrieves the TokenPermissions stored in the request (which must have been
+     * previously added by the TokenPermissionsInterceptor) and checks the relevant
+     * permissions
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final TokenPermissions tokenPermissions = getTokenPermissions(request)
+                .orElseThrow(() -> new IllegalStateException("TokenPermissions object not present in request"));
+
+        boolean hasCompanyAccountsUpdatePermission = tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE);
+
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put("request_method", request.getMethod());
+        debugMap.put("has_company_accounts_update_permission", hasCompanyAccountsUpdatePermission);
+
+        if (hasCompanyAccountsUpdatePermission) {
+            LOGGER.debugRequest(request, "AuthenticationInterceptor authorised with company_accounts=update permission",
+                    debugMap);
+            return true;
+        }
+
+        LOGGER.debugRequest(request, "AuthenticationInterceptor unauthorised", debugMap);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return false;
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.api.accounts.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthenticationInterceptorTest {
+
+    @Spy
+    private AuthenticationInterceptor interceptor;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private TokenPermissions tokenPermissions;
+
+    private final Object handler = null;
+
+    @Test
+    @DisplayName("Test preHandle when request is authorized")
+    void preHandleAuthorized() throws Exception {
+        setupTokenPermissions();
+        final boolean hasCompanyAccountsUpdatePermission = true;
+        when(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE))
+                .thenReturn(hasCompanyAccountsUpdatePermission);
+
+        assertTrue(interceptor.preHandle(request, response, handler));
+    }
+
+    @Test
+    @DisplayName("Test preHandle when request is unauthorized")
+    void preHandleUnauthorized() throws Exception {
+        setupTokenPermissions();
+        final boolean hasCompanyAccountsUpdatePermission = false;
+        when(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE))
+                .thenReturn(hasCompanyAccountsUpdatePermission);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+    }
+
+    @Test
+    @DisplayName("Test preHandle when TokenPermissions is not present in request")
+    void preHandleMissingTokenPermissions() throws Exception {
+        assertThrows(IllegalStateException.class, () -> interceptor.preHandle(request, response, handler));
+    }
+
+    private void setupTokenPermissions() {
+        doReturn(Optional.of(tokenPermissions)).when(interceptor).getTokenPermissions(request);
+    }
+}


### PR DESCRIPTION
Create a new interceptor to check the `company_accounts.update` permission. This requires the `TokenPermissionsInterceptor` to run beforehand and put the relevant object in the session.