### PR TITLE
Fix Sonar issues by changing pom parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,17 +9,40 @@
 
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
-    <artifactId>companies-house-spring-boot-parent</artifactId>
-    <version>1.2.0</version>
-    <relativePath /> <!-- lookup parent from repository -->
+    <artifactId>companies-house-parent</artifactId>
+    <version>1.3.0</version>
   </parent>
 
   <properties>
+    <java.version>1.8</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
     <!-- Dependency Versions -->
-    <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
     <structured-logging.version>1.2.0-rc1</structured-logging.version>
     <api-security-java.version>0.2.9</api-security-java.version>
+
+    <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
+
+    <!-- Maven and Surefire plugins -->
+    <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+    <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-dependencies</artifactId>
+          <version>${spring-boot-dependencies.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Compile -->
@@ -56,24 +79,45 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <fork>true</fork>
+          <meminitial>128m</meminitial>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <maxmem>512m</maxmem>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junit-platform-surefire-provider.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We changed Sonar and, in doing so, needed to upgrade to use a more
 recent companies house parent pom. Just changing to use a newer
 companies-house-spring-boot-parent did not work breaking lots of
 tests. We are not supposed to use that as a parent any more, so
 this is a chance to use the proper companies-house-parent. In doing
 so, other changes to pull in correct spring dependencies were
 needed.
Added encodings, plugins necessary for maven build.