### PR TITLE
Tidying/fix sonar issues and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target/
 *.jar
 *.zip
+build.log
 
 # Eclipse files
 .classpath

--- a/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptorTest.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.api.util.security.Permission.Value;
 import uk.gov.companieshouse.api.util.security.TokenPermissions;
 
 @ExtendWith(MockitoExtension.class)
-public class AuthenticationInterceptorTest {
+class AuthenticationInterceptorTest {
 
     @Spy
     private AuthenticationInterceptor interceptor;


### PR DESCRIPTION
Add a line to gitignore to ignore build.log
Fix a Sonar complaint: unncessary public modifier. With this, we have 0 Sonar issues on this repo.