### PR TITLE
Upgrade api-security-library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <!-- Dependency Versions -->
     <structured-logging.version>1.2.0-rc1</structured-logging.version>
-    <api-security-java.version>0.3.3</api-security-java.version>
+    <api-security-java.version>0.3.4</api-security-java.version>
 
     <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
     <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>


### PR DESCRIPTION
The new version no longer uses the enable token permissions auth feature flag.

Note there was a problem building/releasing 0.3.3  hence this as a follow up of #25 

Resolves FA-1070