### PR TITLE
Upgrade log4j to version 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Dependency Versions -->
-    <structured-logging.version>1.2.0-rc1</structured-logging.version>
+    <structured-logging.version>1.9.10</structured-logging.version>
     <log4j2.version>2.15.0</log4j2.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <api-security-java.version>0.3.4</api-security-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
     <!-- Dependency Versions -->
     <structured-logging.version>1.2.0-rc1</structured-logging.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <api-security-java.version>0.3.4</api-security-java.version>
 
     <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
@@ -34,6 +35,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!--To be removed after spring boot upgrade to the required patch 2.5.8 or 2.6.2
+ More info here https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot   -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${log4j2.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <!-- Dependency Versions -->
     <structured-logging.version>1.2.0-rc1</structured-logging.version>
     <log4j2.version>2.15.0</log4j2.version>
+    <javax.servlet.version>4.0.1</javax.servlet.version>
     <api-security-java.version>0.3.4</api-security-java.version>
 
     <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
@@ -56,6 +57,12 @@
 
   <dependencies>
     <!-- Compile -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${javax.servlet.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>


### PR DESCRIPTION
Due to security vulnerability found in older versions of log4j, it is
required to upgrade it to 2.15.0. This dependency is directly added to the
pom file due to spring boot dependency management which brings the old
version regardless of what version we use in structured-logging. This
dependency would need to be removed once we upgrade spring boot to the
required patch 2.5.8 or 2.6.2. More information about this can be found
here https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

Resolves: DEBT-1435