### PR TITLE
Update Jackson Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   </parent>
 
   <properties>
+    <jackson.version>2.12.3</jackson.version>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -57,6 +58,19 @@
 
   <dependencies>
     <!-- Compile -->
+<!--    Jacson dependencies below will need to be removed as well once the upgrade to newer versions of spring boot-->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
       <version>${structured-logging.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Jackson libraries coming with spring boot are older versions and the
code used in structured logging requires to be on a higher version.
This needs to be added to the pom and will be removed once spring
boot upgrades to the latest version after 23rd Dec.