### PR TITLE
BI-12157-company-accounts-library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Dependency Versions -->
-    <structured-logging.version>1.9.12</structured-logging.version>
+    <structured-logging.version>1.9.14</structured-logging.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <api-security-java.version>0.3.4</api-security-java.version>
 


### PR DESCRIPTION
### [BI-12157](https://companieshouse.atlassian.net/browse/BI-12157) - Log4j version update for version 2.17.1

#### Fix the log4j2 vulnerability CVE-2021-44228 and [Log4J 2 Vulnerability - Developer advice](https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/3587637603/Log4J+2+Vulnerability+-+Developer+advice)

#### Type of change
##### Update  **structured-logging** from **1.9.12** to **1.9.14**