### PR TITLE
[2700] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,19 +15,22 @@
   </parent>
 
   <properties>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.19.1</jackson.version>
     <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Dependency Versions -->
-    <structured-logging.version>3.0.0</structured-logging.version>
+    <structured-logging.version>3.0.37</structured-logging.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
-    <api-security-java.version>2.0.0</api-security-java.version>
+    <api-security-java.version>2.0.11</api-security-java.version>
 
-    <spring-boot-dependencies.version>3.1.3</spring-boot-dependencies.version>
-    <spring-boot-maven-plugin.version>3.1.3</spring-boot-maven-plugin.version>
-
+    <spring-boot-dependencies.version>3.4.8</spring-boot-dependencies.version>
+    <spring-boot-maven-plugin.version>3.4.8</spring-boot-maven-plugin.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
+    <gson.version>2.13.1</gson.version>
+    <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+    <spring-core.version>6.2.9</spring-core.version>
     <!-- Maven and Surefire plugins -->
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -58,7 +61,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
+      <version>${jakarta.servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -83,19 +86,45 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>6.0.9</version>
+      <version>${spring-core.version}</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
       <version>${structured-logging.version}</version>
+      <exclusions>
+        <!-- Excluding to address CVE-2025-48924. commons-lang3-3.17.0 is pulled transitively-->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- included to address CVE-2025-48924-->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>api-security-java</artifactId>
       <version>${api-security-java.version}</version>
+      <exclusions>
+        <!-- Excluding to address CVE-2025-53864. gson-2.11.0 is pulled transitively-->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
 - Replaced hard-coded versions in dependencies with property references
 - excluded commons-lang3 and gson
 - CVEs resolved CVE-2025-48924,CVE-2023-35116,CVE-2024-22259,CVE-2024-38809,CVE-2024-38816
 - Bumped the following dependencies
   - jackson-core version to 2.19.1
   - structured-logging version to 3.0.37
   - api-security-java version to 2.0.11
   - spring-boot-maven-plugin version to 3.4.8
   - spring-boot-dependencies version to 3.4.8
   - commons-lang3 version to 3.18.0
   - gson version to 2.13.1
   - spring-core version to 6.2.9