### PR TITLE
[CC-2785] - clean pom and upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,15 +21,16 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Dependency Versions -->
-    <structured-logging.version>3.0.37</structured-logging.version>
+    <structured-logging.version>3.0.42</structured-logging.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
-    <api-security-java.version>2.0.11</api-security-java.version>
+    <api-security-java.version>2.0.15</api-security-java.version>
 
     <spring-boot-dependencies.version>3.4.9</spring-boot-dependencies.version>
     <spring-boot-maven-plugin.version>3.4.9</spring-boot-maven-plugin.version>
-    <commons-lang3.version>3.18.0</commons-lang3.version>
-    <gson.version>2.13.1</gson.version>
-    <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+    <commons-lang3.version>3.19.0</commons-lang3.version>
+    <gson.version>2.13.2</gson.version>
+    <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
+    <junit-jupiter-engine.version>5.10.5</junit-jupiter-engine.version>
     <!-- Maven and Surefire plugins -->
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -130,6 +131,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter-engine.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
  - bump the following dependencies version
    - structured-logging to 3.0.42
    - api-security-java to 2.0.15
    - commons-lang3 to 3.19.0
    - gson to 2.13.2
    - jakarta.servlet-api to 6.1.0
  - add junit-jupiter-engine dependency version
  - https://companieshouse.atlassian.net/browse/CC-2785